### PR TITLE
Adding Traefik 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ microk8s_plugin_fluentd_enable: false
 microk8s_plugin_prometheus_enable: false
 microk8s_plugin_host_access_enable: true
 microk8s_plugin_metallb_enable: false
+microk8s_plugin_traefik_enable: false
 microk8s_plugin_registry_size: 20Gi
 
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -130,6 +130,13 @@
   changed_when: "'Addon host-access is already enabled' not in command_result.stdout"
   when: microk8s_plugin_host_access_enable
 
+- name: Enable traefik
+  become: yes
+  command: "microk8s.enable traefik"
+  register: command_result
+  changed_when: "'Addon traefik is already enabled' not in command_result.stdout"
+  when: microk8s_plugin_traefik_enable
+
 - name: Disable snap autoupdate
   blockinfile:
     dest: /etc/hosts


### PR DESCRIPTION
Hello,

This PR adds support for Traefik. Traefik was added to the list of add-ons in MicroK8s starting with version 1.20/stable. 

Please let me know if anything else is needed. Thanks! 

Signed-off-by: Christopher P. Maher <chris@mahercode.io>