### PR TITLE
Linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,7 @@ $RECYCLE.BIN/
 __pycache__
 .cache
 .molecule
+
+### virtual env ###
+venv/
+.venv/

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,10 @@
 # Based on ansible-lint config
 extends: default
 
+ignore: |
+  venv/
+  .venv/
+
 rules:
   braces:
     max-spaces-inside: 1

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-Ansible Role: microk8s
-==================
+# Ansible Role: microk8s
 
 Role to download and install [microk8s](https://microk8s.io/) the smallest, simplest, pure production K8s.
 
 
-Requirements
-------------
+## Requirements
 
 * Ansible >= 2.7
 
@@ -20,8 +18,7 @@ Requirements
             * Bionic (18.04)
 
 
-Role Variables
---------------
+## Role Variables
 
 Some variables available in this role are listed here.  The full set is
 defined in `[defaults/main.yml](defaults/main.yml)`.
@@ -32,8 +29,7 @@ defined in `[defaults/main.yml](defaults/main.yml)`.
 * `microk8s_group_HA: microk8s_HA`: Hostgroup whose members will form HA
   cluster.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
@@ -41,23 +37,21 @@ Example Playbook
     - role: istvano.microk8s
 ```
 
-License
--------
+## License
 
 MIT
 
-Test
--------
+## Test
 
-## Using Molecule wrapper and system Python
+### Using Molecule wrapper and system Python
 
-* ./moleculew lint
-* ./moleculew create
-* ./moleculew list
-* ./moleculew check
-* ./moleculew test
+* `./moleculew lint`
+* `./moleculew create`
+* `./moleculew list`
+* `./moleculew check`
+* `./moleculew test`
 
-## Using Python virtual environment
+### Using Python virtual environment
 
 * Set up virtual environment
     ```

--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Requirements
 Role Variables
 --------------
 
-The following variables will change the behavior of this role (default values
-are shown below):
+Some variables available in this role are listed here.  The full set is
+defined in `[defaults/main.yml](defaults/main.yml)`.
 
-```yaml
-# microk8s version number
-microk8s_version: '1.19/stable'
-
+* `microk8s_version`: Version to use, defaults to `1.19/stable`.
+* `microk8s_plugin_*_enable: true`: Enable/disable various plugins.
+* `microk8s_enable_HA: false`: Enable/disable high-availability.
+* `microk8s_group_HA: microk8s_HA`: Hostgroup whose members will form HA
+  cluster.
 
 Example Playbook
 ----------------
@@ -48,8 +49,42 @@ MIT
 Test
 -------
 
+## Using Molecule wrapper and system Python
+
 * ./moleculew lint
 * ./moleculew create
 * ./moleculew list
 * ./moleculew check
 * ./moleculew test
+
+## Using Python virtual environment
+
+* Set up virtual environment
+    ```
+    $ python3 -m venv venv
+    ```
+* Activate the environment
+    ```
+    $ . venv/bin/activate
+    ```
+* Install Molecule with lint and Docker options
+    ```
+    $ pip install 'molecule[lint,docker]'
+    ```
+* Install up-to-date Ansible package if necessary
+    ```
+    $ pip install ansible
+    ```
+* Add the following to your `.yamllint`:
+    ```
+    ignore: |
+      venv/
+    ```
+    It might be necessary to run `molecule lint` first in order to create the
+    `.yamllint` file.
+* Run the test commands:
+  * `molecule lint`
+  * `molecule create`
+  * `molecule list`
+  * `molecule check`
+  * `molecule test`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,18 @@
 ---
+#
 # defaults file for ansible_role_microk8s
-microk8s_version: "1.19/stable"
+#
 
+# version management
+microk8s_version: "1.19/stable"
+microk8s_disable_snap_autoupdate: false
+
+# plugin configuration
 microk8s_plugin_dns_enable: true
 microk8s_plugin_rbac_enable: true
 microk8s_plugin_storage_enable: true
 microk8s_plugin_registry_enable: true
 microk8s_plugin_metricsserver_enable: true
-microk8s_plugin_helm3_enable: true
 microk8s_plugin_ingress_enable: true
 microk8s_plugin_dashboard_enable: true
 microk8s_plugin_fluentd_enable: false
@@ -16,16 +21,16 @@ microk8s_plugin_host_access_enable: true
 microk8s_plugin_metallb_enable: false
 microk8s_plugin_traefik_enable: false
 microk8s_plugin_registry_size: 20Gi
-
-
+microk8s_plugin_helm3_enable: true
 microk8s_plugin_helm3_repositories:
   - name: stable
     url: https://charts.helm.sh/stable
 
-# users to set up microk8s for
+# users to make members of microk8s group
 users: []
 
+# enable high-availability?
 microk8s_enable_HA: false
-microk8s_group_HA: "microk8s_HA"
 
-microk8s_disable_snap_autoupdate: false
+# hostgroup whose members will form high-availability cluster
+microk8s_group_HA: "microk8s_HA"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   role_name: microk8s
+  namespace: istvano
   description: Ansible role for installing and set-up microk8s.
   author: Istvan Orban
   company: Urban and Co Ltd.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,8 +5,10 @@ dependency:
 driver:
   name: docker
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
 
 platforms:
   - name: ansible_role_microk8s_default

--- a/molecule/ubuntu_max/molecule.yml
+++ b/molecule/ubuntu_max/molecule.yml
@@ -5,8 +5,10 @@ dependency:
 driver:
   name: docker
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
 
 platforms:
   - name: ansible_role_microk8s_ubuntu_max

--- a/molecule/ubuntu_min/molecule.yml
+++ b/molecule/ubuntu_min/molecule.yml
@@ -5,8 +5,10 @@ dependency:
 driver:
   name: docker
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
 
 platforms:
   - name: ansible_role_microk8s_ubuntu_min

--- a/tasks/configure-groups.yml
+++ b/tasks/configure-groups.yml
@@ -49,10 +49,9 @@
 - name: add helm repository to user
   become: yes
   become_user: '{{ user }}'
-  shell: "helm repo add stable https://charts.helm.sh/stable"
-  args:
-    executable: /bin/bash
-  changed_when: true
+  community.kubernetes.helm_repository:
+    name: stable
+    repo_url: https://charts.helm.sh/stable
   with_items: '{{ users }}'
   loop_control:
     loop_var: user
@@ -62,10 +61,8 @@
 - name: update helm repos
   become: yes
   become_user: '{{ user }}'
-  shell: "helm repo update"
-  args:
-    executable: /bin/bash
-  changed_when: true
+  community.kubernetes.helm:
+    update_cache: yes
   with_items: '{{ users }}'
   loop_control:
     loop_var: user

--- a/tasks/configure-groups.yml
+++ b/tasks/configure-groups.yml
@@ -9,7 +9,7 @@
     loop_var: user
     label: '{{ user }}'
 
-- name: create .kube folder for the user
+- name: Create .kube folder for the user
   become: yes
   become_user: '{{ user }}'
   file:
@@ -17,6 +17,7 @@
     state: directory
     owner: '{{ user }}'
     group: '{{ user }}'
+    mode: 0750
   with_items: '{{ users }}'
   loop_control:
     loop_var: user

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
   command: "snap alias microk8s.kubectl kubectl"
   changed_when: false
   register: aliaskubectlout
-  
+
 - name: Create helm3 alias
   become: yes
   command: "snap alias microk8s.helm3 helm"
@@ -40,14 +40,14 @@
   register: aliashelmout
   when: microk8s_plugin_helm3_enable
 
-- name: create folder for microk8s certificates
+- name: Create folder for microk8s certificates
   become: yes
   file:
     path: /usr/share/ca-certificates/extra
     state: directory
     mode: 0750
 
-- name: copy certificates
+- name: Copy certificates
   become: yes
   copy:
     src: "{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,6 +45,7 @@
   file:
     path: /usr/share/ca-certificates/extra
     state: directory
+    mode: 0750
 
 - name: copy certificates
   become: yes
@@ -53,6 +54,7 @@
     dest: /usr/share/ca-certificates/extra
     remote_src: yes
     force: yes
+    mode: 0644
   with_fileglob:
     - /var/snap/microk8s/current/certs/*ca*.crt
 


### PR DESCRIPTION
Fix linting errors when using either repo's `moleculew` wrapper or Molecule in a Python virtual environment.  Updated to use newer Molecule syntax for `lint:` (unfortunately breaks use of moleculew).

Minor updates to documentation.

@istvano: I am not experienced with Molecule and new to Ansible.  I have an addition to make to your module and started with forking and running the tests, which led to the linting issues, which I tried to fix so I can move on to the other additions--I hope this can be useful so please let me know if I should try something else.

In my environment the testing failed repeatedly under either the wrapper and Python 2.7 or Molecule and Python 3.9: Docker was unable to start snapd and so was unable to install microk8s.  This was reported as being `unable to find microk8s`.