### PR TITLE
Custom CSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,7 @@ $RECYCLE.BIN/
 __pycache__
 .cache
 .molecule
+
+### virtual env ###
+venv/
+.venv/

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,10 @@
 # Based on ansible-lint config
 extends: default
 
+ignore: |
+  venv/
+  .venv/
+
 rules:
   braces:
     max-spaces-inside: 1

--- a/README.md
+++ b/README.md
@@ -69,13 +69,6 @@ MIT
     ```
     $ pip install ansible
     ```
-* Add the following to your `.yamllint`:
-    ```
-    ignore: |
-      venv/
-    ```
-    It might be necessary to run `molecule lint` first in order to create the
-    `.yamllint` file.
 * Run the test commands:
   * `molecule lint`
   * `molecule create`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-Ansible Role: microk8s
-==================
+# Ansible Role: microk8s
 
 Role to download and install [microk8s](https://microk8s.io/) the smallest, simplest, pure production K8s.
 
 
-Requirements
-------------
+## Requirements
 
 * Ansible >= 2.7
 
@@ -20,8 +18,7 @@ Requirements
             * Bionic (18.04)
 
 
-Role Variables
---------------
+## Role Variables
 
 Some variables available in this role are listed here.  The full set is
 defined in `[defaults/main.yml](defaults/main.yml)`.
@@ -32,8 +29,7 @@ defined in `[defaults/main.yml](defaults/main.yml)`.
 * `microk8s_group_HA: microk8s_HA`: Hostgroup whose members will form HA
   cluster.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
@@ -41,23 +37,21 @@ Example Playbook
     - role: istvano.microk8s
 ```
 
-License
--------
+## License
 
 MIT
 
-Test
--------
+## Test
 
-## Using Molecule wrapper and system Python
+### Using Molecule wrapper and system Python
 
-* ./moleculew lint
-* ./moleculew create
-* ./moleculew list
-* ./moleculew check
-* ./moleculew test
+* `./moleculew lint`
+* `./moleculew create`
+* `./moleculew list`
+* `./moleculew check`
+* `./moleculew test`
 
-## Using Python virtual environment
+### Using Python virtual environment
 
 * Set up virtual environment
     ```

--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Requirements
 Role Variables
 --------------
 
-The following variables will change the behavior of this role (default values
-are shown below):
+Some variables available in this role are listed here.  The full set is
+defined in `[defaults/main.yml](defaults/main.yml)`.
 
-```yaml
-# microk8s version number
-microk8s_version: '1.19/stable'
-
+* `microk8s_version`: Version to use, defaults to `1.19/stable`.
+* `microk8s_plugin_*_enable: true`: Enable/disable various plugins.
+* `microk8s_enable_HA: false`: Enable/disable high-availability.
+* `microk8s_group_HA: microk8s_HA`: Hostgroup whose members will form HA
+  cluster.
 
 Example Playbook
 ----------------
@@ -48,8 +49,42 @@ MIT
 Test
 -------
 
+## Using Molecule wrapper and system Python
+
 * ./moleculew lint
 * ./moleculew create
 * ./moleculew list
 * ./moleculew check
 * ./moleculew test
+
+## Using Python virtual environment
+
+* Set up virtual environment
+    ```
+    $ python3 -m venv venv
+    ```
+* Activate the environment
+    ```
+    $ . venv/bin/activate
+    ```
+* Install Molecule with lint and Docker options
+    ```
+    $ pip install 'molecule[lint,docker]'
+    ```
+* Install up-to-date Ansible package if necessary
+    ```
+    $ pip install ansible
+    ```
+* Add the following to your `.yamllint`:
+    ```
+    ignore: |
+      venv/
+    ```
+    It might be necessary to run `molecule lint` first in order to create the
+    `.yamllint` file.
+* Run the test commands:
+  * `molecule lint`
+  * `molecule create`
+  * `molecule list`
+  * `molecule check`
+  * `molecule test`

--- a/README.md
+++ b/README.md
@@ -2,34 +2,35 @@
 
 Role to download and install [microk8s](https://microk8s.io/) the smallest, simplest, pure production K8s.
 
-
 ## Requirements
 
 * Ansible >= 2.7
-
 * Linux Distribution
-
     * Debian Family
-
-
         * Ubuntu
-
             * Xenial (16.04)
             * Bionic (18.04)
+    * Arch Linux (untested)
 
+## License
 
-## Role Variables
+MIT
+
+## Usage
+
+### Role Variables
 
 Some variables available in this role are listed here.  The full set is
 defined in `[defaults/main.yml](defaults/main.yml)`.
 
 * `microk8s_version`: Version to use, defaults to `1.19/stable`.
-* `microk8s_plugin_*_enable: true`: Enable/disable various plugins.
-* `microk8s_enable_HA: false`: Enable/disable high-availability.
-* `microk8s_group_HA: microk8s_HA`: Hostgroup whose members will form HA
-  cluster.
+* `microk8s_plugin_*_enable`: Enable/disable various plugins.
+* `microk8s_enable_HA`: Enable/disable high-availability.
+* `microk8s_group_HA`: Hostgroup whose members will form HA cluster.
+* `microk8s_csr_template`: If defined, will cause a custom CSR to be used in
+  generating certificates.
 
-## Example Playbook
+### Basic playbook
 
 ```yaml
 - hosts: servers
@@ -37,11 +38,20 @@ defined in `[defaults/main.yml](defaults/main.yml)`.
     - role: istvano.microk8s
 ```
 
-## License
+### Custom certificate request template
 
-MIT
+It might be useful to customize the certificate request template used by
+MicroK8s in generating cluster certificates.  For example, additional SANs can
+be added to the certificates such that the MicroK8s certificates validate when
+addressed from outside the cluster, such as through a reverse proxy.
 
-## Test
+To generate a CSR template, the easiest is probably to use the role without
+a template, and then copy the CSR in
+`/var/snap/microk8s/current/certs/csr.conf.template` to your playbook's
+templates directory, make the edits and set the `microk8s_csr_template`
+variable accordingly, and re-run the playbook.
+
+## Testing
 
 ### Using Molecule wrapper and system Python
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,6 @@ microk8s_enable_HA: false
 
 # hostgroup whose members will form high-availability cluster
 microk8s_group_HA: "microk8s_HA"
+
+# for setting up custom certificate request.  Set to template name to enable
+#microk8s_csr_template: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,18 @@
 ---
+#
 # defaults file for ansible_role_microk8s
-microk8s_version: "1.19/stable"
+#
 
+# version management
+microk8s_version: "1.19/stable"
+microk8s_disable_snap_autoupdate: false
+
+# plugin configuration
 microk8s_plugin_dns_enable: true
 microk8s_plugin_rbac_enable: true
 microk8s_plugin_storage_enable: true
 microk8s_plugin_registry_enable: true
 microk8s_plugin_metricsserver_enable: true
-microk8s_plugin_helm3_enable: true
 microk8s_plugin_ingress_enable: true
 microk8s_plugin_dashboard_enable: true
 microk8s_plugin_fluentd_enable: false
@@ -16,16 +21,16 @@ microk8s_plugin_host_access_enable: true
 microk8s_plugin_metallb_enable: false
 microk8s_plugin_traefik_enable: false
 microk8s_plugin_registry_size: 20Gi
-
-
+microk8s_plugin_helm3_enable: true
 microk8s_plugin_helm3_repositories:
   - name: stable
     url: https://charts.helm.sh/stable
 
-# users to set up microk8s for
+# users to make members of microk8s group
 users: []
 
+# enable high-availability?
 microk8s_enable_HA: false
-microk8s_group_HA: "microk8s_HA"
 
-microk8s_disable_snap_autoupdate: false
+# hostgroup whose members will form high-availability cluster
+microk8s_group_HA: "microk8s_HA"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
 # handlers file for ansible_role_microk8s
+
+- name: Refresh certs
+  become: yes
+  command: microk8s refresh-certs

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   role_name: microk8s
+  namespace: istvano
   description: Ansible role for installing and set-up microk8s.
   author: Istvan Orban
   company: Urban and Co Ltd.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,8 +5,10 @@ dependency:
 driver:
   name: docker
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
 
 platforms:
   - name: ansible_role_microk8s_default

--- a/molecule/ubuntu_max/molecule.yml
+++ b/molecule/ubuntu_max/molecule.yml
@@ -5,8 +5,10 @@ dependency:
 driver:
   name: docker
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
 
 platforms:
   - name: ansible_role_microk8s_ubuntu_max

--- a/molecule/ubuntu_min/molecule.yml
+++ b/molecule/ubuntu_min/molecule.yml
@@ -5,8 +5,10 @@ dependency:
 driver:
   name: docker
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
 
 platforms:
   - name: ansible_role_microk8s_ubuntu_min

--- a/tasks/configure-HA.yml
+++ b/tasks/configure-HA.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Enumerate all cluster hosts within the hosts file
+  become: yes
   blockinfile:
     dest: /etc/hosts
     marker: "# {mark} ANSIBLE MANAGED: microk8s HA Cluster Hosts"

--- a/tasks/configure-groups.yml
+++ b/tasks/configure-groups.yml
@@ -49,10 +49,9 @@
 - name: add helm repository to user
   become: yes
   become_user: '{{ user }}'
-  shell: "helm repo add stable https://charts.helm.sh/stable"
-  args:
-    executable: /bin/bash
-  changed_when: true
+  community.kubernetes.helm_repository:
+    name: stable
+    repo_url: https://charts.helm.sh/stable
   with_items: '{{ users }}'
   loop_control:
     loop_var: user
@@ -62,10 +61,8 @@
 - name: update helm repos
   become: yes
   become_user: '{{ user }}'
-  shell: "helm repo update"
-  args:
-    executable: /bin/bash
-  changed_when: true
+  community.kubernetes.helm:
+    update_cache: yes
   with_items: '{{ users }}'
   loop_control:
     loop_var: user

--- a/tasks/configure-groups.yml
+++ b/tasks/configure-groups.yml
@@ -9,7 +9,7 @@
     loop_var: user
     label: '{{ user }}'
 
-- name: create .kube folder for the user
+- name: Create .kube folder for the user
   become: yes
   become_user: '{{ user }}'
   file:
@@ -17,6 +17,7 @@
     state: directory
     owner: '{{ user }}'
     group: '{{ user }}'
+    mode: 0750
   with_items: '{{ users }}'
   loop_control:
     loop_var: user

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
   command: "snap alias microk8s.kubectl kubectl"
   changed_when: false
   register: aliaskubectlout
-  
+
 - name: Create helm3 alias
   become: yes
   command: "snap alias microk8s.helm3 helm"
@@ -40,14 +40,14 @@
   register: aliashelmout
   when: microk8s_plugin_helm3_enable
 
-- name: create folder for microk8s certificates
+- name: Create folder for microk8s certificates
   become: yes
   file:
     path: /usr/share/ca-certificates/extra
     state: directory
     mode: 0750
 
-- name: copy certificates
+- name: Copy certificates
   become: yes
   copy:
     src: "{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,6 +45,7 @@
   file:
     path: /usr/share/ca-certificates/extra
     state: directory
+    mode: 0750
 
 - name: copy certificates
   become: yes
@@ -53,6 +54,7 @@
     dest: /usr/share/ca-certificates/extra
     remote_src: yes
     force: yes
+    mode: 0644
   with_fileglob:
     - /var/snap/microk8s/current/certs/*ca*.crt
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,7 +43,7 @@
 - name: Create custom certificates
   become: yes
   ansible.builtin.template:
-    src: microk8s_csr_template
+    src: "{{ microk8s_csr_template }}"
     dest: /var/snap/microk8s/current/certs/csr.conf.template
     mode: 0644
   when: microk8s_csr_template is defined and microk8s_csr_template is file

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,12 +40,22 @@
   register: aliashelmout
   when: microk8s_plugin_helm3_enable
 
+- name: Create custom certificates
+  become: yes
+  ansible.builtin.template:
+    src: microk8s_csr_template
+    dest: /var/snap/microk8s/current/certs/csr.conf.template
+    mode: 0644
+  when: microk8s_csr_template is defined and microk8s_csr_template is file
+  notify:
+  - Refresh certs
+
 - name: Create folder for microk8s certificates
   become: yes
   file:
     path: /usr/share/ca-certificates/extra
     state: directory
-    mode: 0750
+    mode: 0755
 
 - name: Copy certificates
   become: yes
@@ -71,12 +81,26 @@
   changed_when: "'Addon rbac is already enabled' not in command_result.stdout"
   when: microk8s_plugin_rbac_enable
 
+- name: Disable rbac
+  become: yes
+  command: "microk8s.disable rbac"
+  register: command_result
+  changed_when: "'Addon rbac is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_rbac_enable
+
 - name: Enable dns
   become: yes
   command: "microk8s.enable dns"
   register: command_result
   changed_when: "'Addon dns is already enabled' not in command_result.stdout"
   when: microk8s_plugin_dns_enable
+
+- name: Disable dns
+  become: yes
+  command: "microk8s.disable dns"
+  register: command_result
+  changed_when: "'Addon dns is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_dns_enable
 
 - name: Enable storage
   become: yes
@@ -85,12 +109,26 @@
   changed_when: "'Addon storage is already enabled' not in command_result.stdout"
   when: microk8s_plugin_storage_enable
 
+- name: Disable storage
+  become: yes
+  command: "microk8s.disable storage"
+  register: command_result
+  changed_when: "'Addon storage is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_storage_enable
+
 - name: Enable registry
   become: yes
   command: "microk8s.enable registry:size={{ microk8s_plugin_registry_size }}"
   register: command_result
   changed_when: "'Addon registry is already enabled' not in command_result.stdout"
   when: microk8s_plugin_registry_enable
+
+- name: Disable registry
+  become: yes
+  command: "microk8s.disable registry:size={{ microk8s_plugin_registry_size }}"
+  register: command_result
+  changed_when: "'Addon registry is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_registry_enable
 
 - name: Enable metrics-server
   become: yes
@@ -99,12 +137,26 @@
   changed_when: "'Addon metrics-server is already enabled' not in command_result.stdout"
   when: microk8s_plugin_metricsserver_enable
 
+- name: Disable metrics-server
+  become: yes
+  command: "microk8s.disable metrics-server"
+  register: command_result
+  changed_when: "'Addon metrics-server is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_metricsserver_enable
+
 - name: Enable helm3
   become: yes
   command: "microk8s.enable helm3"
   register: command_result
   changed_when: "'Addon helm3 is already enabled' not in command_result.stdout"
   when: microk8s_plugin_helm3_enable
+
+- name: Disable helm3
+  become: yes
+  command: "microk8s.disable helm3"
+  register: command_result
+  changed_when: "'Addon helm3 is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_helm3_enable
 
 - name: Enable ingress
   become: yes
@@ -113,12 +165,26 @@
   changed_when: "'Addon ingress is already enabled' not in command_result.stdout"
   when: microk8s_plugin_ingress_enable
 
+- name: Disable ingress
+  become: yes
+  command: "microk8s.disable ingress"
+  register: command_result
+  changed_when: "'Addon ingress is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_ingress_enable
+
 - name: Enable dashboard
   become: yes
   command: "microk8s.enable dashboard"
   register: command_result
   changed_when: "'Addon dashboard is already enabled' not in command_result.stdout"
   when: microk8s_plugin_dashboard_enable
+
+- name: Disable dashboard
+  become: yes
+  command: "microk8s.disable dashboard"
+  register: command_result
+  changed_when: "'Addon dashboard is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_dashboard_enable
 
 - name: Enable fluentd
   become: yes
@@ -127,12 +193,26 @@
   changed_when: "'Addon fluentd is already enabled' not in command_result.stdout"
   when: microk8s_plugin_fluentd_enable
 
+- name: Disable fluentd
+  become: yes
+  command: "microk8s.disable fluentd"
+  register: command_result
+  changed_when: "'Addon fluentd is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_fluentd_enable
+
 - name: Enable prometheus
   become: yes
   command: "microk8s.enable prometheus"
   register: command_result
   changed_when: "'Addon prometheus is already enabled' not in command_result.stdout"
   when: microk8s_plugin_prometheus_enable
+
+- name: Disable prometheus
+  become: yes
+  command: "microk8s.disable prometheus"
+  register: command_result
+  changed_when: "'Addon prometheus is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_prometheus_enable
 
 - name: Enable metallb
   become: yes
@@ -141,6 +221,13 @@
   changed_when: "'Addon metallb is already enabled' not in command_result.stdout"
   when: microk8s_plugin_metallb_enable
 
+- name: Disable metallb
+  become: yes
+  command: "microk8s.disable metallb"
+  register: command_result
+  changed_when: "'Addon metallb is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_metallb_enable
+
 - name: Enable host access
   become: yes
   command: "microk8s.enable host-access"
@@ -148,12 +235,26 @@
   changed_when: "'Addon host-access is already enabled' not in command_result.stdout"
   when: microk8s_plugin_host_access_enable
 
+- name: Disable host access
+  become: yes
+  command: "microk8s.disable host-access"
+  register: command_result
+  changed_when: "'Addon host-access is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_host_access_enable
+
 - name: Enable traefik
   become: yes
   command: "microk8s.enable traefik"
   register: command_result
   changed_when: "'Addon traefik is already enabled' not in command_result.stdout"
   when: microk8s_plugin_traefik_enable
+
+- name: Disable traefik
+  become: yes
+  command: "microk8s.disable traefik"
+  register: command_result
+  changed_when: "'Addon traefik is already disabled' not in command_result.stdout"
+  when: not microk8s_plugin_traefik_enable
 
 - name: Disable snap autoupdate
   blockinfile:


### PR DESCRIPTION
This PR is based on #10's changes and adds support for a custom CSR.  A custom CSR allows me to support custom SANs such that I can access the k8s cluster behind a reverse proxy with full certificate validation.

This PR also implements disabling of plugins that are currently enabled but where `microk8s_plugin_*_enable` is set to `false`.

I have not yet attempted to create tests for this additional functionality.  As noted in #10, I am unable to run functional tests in my environment yet.

As such this is currently a draft PR.  Any advice on running the molecule suite successfully welcome. :)