### PR TITLE
Enable any plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some variables available in this role are listed here.  The full set is
 defined in `[defaults/main.yml](defaults/main.yml)`.
 
 * `microk8s_version`: Version to use, defaults to `1.19/stable`.
-* `microk8s_plugin_*_enable`: Enable/disable various plugins.
+* `microk8s_plugins`: Enable/disable various plugins.
 * `microk8s_enable_HA`: Enable/disable high-availability.
 * `microk8s_group_HA`: Hostgroup whose members will form HA cluster.
 * `microk8s_csr_template`: If defined, will cause a custom CSR to be used in
@@ -36,6 +36,10 @@ defined in `[defaults/main.yml](defaults/main.yml)`.
 - hosts: servers
   roles:
     - role: istvano.microk8s
+      vars:
+        plugins:
+          istio: true
+          ingress: true
 ```
 
 ### Custom certificate request template

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ defined in `[defaults/main.yml](defaults/main.yml)`.
   roles:
     - role: istvano.microk8s
       vars:
-        plugins:
+        microk8s_plugins:
           istio: true
           ingress: true
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ microk8s_version: "1.19/stable"
 microk8s_disable_snap_autoupdate: false
 
 # plugin configuration
-plugins:
+microk8s_plugins:
   dashboard: true      # The Kubernetes dashboard
   dns: true            # CoreDNS
   helm3: true          # Helm 3 - Kubernetes package manager

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,21 +8,34 @@ microk8s_version: "1.19/stable"
 microk8s_disable_snap_autoupdate: false
 
 # plugin configuration
-microk8s_plugin_dns_enable: true
-microk8s_plugin_rbac_enable: true
-microk8s_plugin_storage_enable: true
-microk8s_plugin_registry_enable: true
-microk8s_plugin_metricsserver_enable: true
-microk8s_plugin_ingress_enable: true
-microk8s_plugin_dashboard_enable: true
-microk8s_plugin_fluentd_enable: false
-microk8s_plugin_prometheus_enable: false
-microk8s_plugin_host_access_enable: true
-microk8s_plugin_metallb_enable: false
-microk8s_plugin_traefik_enable: false
-microk8s_plugin_registry_size: 20Gi
-microk8s_plugin_helm3_enable: true
-microk8s_plugin_helm3_repositories:
+plugins:
+  dashboard: true      # The Kubernetes dashboard
+  dns: true            # CoreDNS
+  helm3: true          # Helm 3 - Kubernetes package manager
+  host-access: true    # Allow Pods connecting to Host services smoothly
+  ingress: true        # Ingress controller for external access
+  metrics-server: true # K8s Metrics Server for API access to service metrics
+  rbac: true           # Role-Based Access Control for authorisation
+  registry: true       # Private image registry exposed on localhost:32000
+  storage: true        # Storage class; allocates storage from host directory
+  ambassador: false    # Ambassador API Gateway and Ingress
+  cilium: false        # SDN, fast with full network policy
+  fluentd: false       # Elasticsearch-Fluentd-Kibana logging and monitoring
+  gpu: false           # Automatic enablement of Nvidia CUDA
+  helm: false          # Helm 2 - the package manager for Kubernetes
+  istio: false         # Core Istio service mesh services
+  jaeger: false        # Kubernetes Jaeger operator with its simple config
+  knative: false       # The Knative framework on Kubernetes.
+  kubeflow: false      # Kubeflow for easy ML deployments
+  linkerd: false       # Linkerd is a service mesh for Kubernetes and other frameworks
+  metallb: false       # Loadbalancer for your Kubernetes cluster
+  multus: false        # Multus CNI enables attaching multiple network interfaces to pods
+  prometheus: false    # Prometheus operator for monitoring and logging
+  traefik: false
+
+
+registry_size: 20Gi
+helm3_repositories:
   - name: stable
     url: https://charts.helm.sh/stable
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
   command: "snap alias microk8s.helm3 helm"
   changed_when: false
   register: aliashelmout
-  when: microk8s_plugin_helm3_enable
+  when: plugins.helm
 
 - name: Create custom certificates
   become: yes
@@ -96,17 +96,17 @@
 
 - name: Enable registry
   become: yes
-  command: "microk8s.enable registry:size={{ microk8s_plugin_registry_size }}"
+  command: "microk8s.enable registry:size={{ registry_size }}"
   register: command_result
   changed_when: "'Addon registry is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_registry_enable
+  when: plugins.registry
 
 - name: Disable registry
   become: yes
-  command: "microk8s.disable registry:size={{ microk8s_plugin_registry_size }}"
+  command: "microk8s.disable registry:size={{ registry_size }}"
   register: command_result
   changed_when: "'Addon registry is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_registry_enable
+  when: not plugins.registry
 
 - name: Disable snap autoupdate
   blockinfile:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -79,7 +79,7 @@
   loop: "{{ plugins | dict2items | item.key != 'registry'}}"
   command: "microk8s.enable {{ item.key }}"
   loop_control: 
-    label: {{ item.name }}
+    label: "{{ item.key }}"
   register: command_result
   changed_when: "'Addon {{ item.key }} is already enabled' not in command_result.stdout"
   when: item.value
@@ -89,7 +89,7 @@
   loop: "{{ plugins | dict2items | item.value != 'registry'}}"
   command: "microk8s.disable {{ item.key }}"
   loop_control: 
-    label: {{ item.name }}
+    label: "{{ item.key }}""
   register: command_result
   changed_when: "'Addon {{ item.key }} is already disabled' not in command_result.stdout"
   when: not item.value

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -74,25 +74,25 @@
   register: command_result
   changed_when: "'0 added, 0 removed' not in command_result.stdout"
 
-- name: Enable {{ item.key }}
+- name: Enable plugins
   become: yes
-  loop: "{{ plugins | dict2items | item.key != 'registry'}}"
+  loop: "{{ plugins | dict2items }}"
   command: "microk8s.enable {{ item.key }}"
   loop_control: 
     label: "{{ item.key }}"
   register: command_result
   changed_when: "'Addon {{ item.key }} is already enabled' not in command_result.stdout"
-  when: item.value
+  when: item.value and item.key != "registry"
 
-- name: Disable {{ item.key }}
+- name: Disable plugins
   become: yes
-  loop: "{{ plugins | dict2items | item.value != 'registry'}}"
+  loop: "{{ plugins | dict2items }}"
   command: "microk8s.disable {{ item.key }}"
   loop_control: 
     label: "{{ item.key }}"
   register: command_result
   changed_when: "'Addon {{ item.key }} is already disabled' not in command_result.stdout"
-  when: not item.value
+  when: not item.value and item.key != "registry"
 
 - name: Enable registry
   become: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -89,7 +89,7 @@
   loop: "{{ plugins | dict2items | item.value != 'registry'}}"
   command: "microk8s.disable {{ item.key }}"
   loop_control: 
-    label: "{{ item.key }}""
+    label: "{{ item.key }}"
   register: command_result
   changed_when: "'Addon {{ item.key }} is already disabled' not in command_result.stdout"
   when: not item.value

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -78,6 +78,8 @@
   become: yes
   loop: "{{ plugins | dict2items | item.key != 'registry'}}"
   command: "microk8s.enable {{ item.key }}"
+  loop_control: 
+    label: {{ item.name }}
   register: command_result
   changed_when: "'Addon {{ item.key }} is already enabled' not in command_result.stdout"
   when: item.value
@@ -86,6 +88,8 @@
   become: yes
   loop: "{{ plugins | dict2items | item.value != 'registry'}}"
   command: "microk8s.disable {{ item.key }}"
+  loop_control: 
+    label: {{ item.name }}
   register: command_result
   changed_when: "'Addon {{ item.key }} is already disabled' not in command_result.stdout"
   when: not item.value

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -76,7 +76,7 @@
 
 - name: Enable plugins
   become: yes
-  loop: "{{ plugins | dict2items }}"
+  loop: "{{ microk8s_plugins | dict2items }}"
   command: "microk8s.enable {{ item.key }}"
   loop_control: 
     label: "{{ item.key }}"
@@ -86,7 +86,7 @@
 
 - name: Disable plugins
   become: yes
-  loop: "{{ plugins | dict2items }}"
+  loop: "{{ microk8s_plugins | dict2items }}"
   command: "microk8s.disable {{ item.key }}"
   loop_control: 
     label: "{{ item.key }}"
@@ -99,14 +99,14 @@
   command: "microk8s.enable registry:size={{ registry_size }}"
   register: command_result
   changed_when: "'Addon registry is already enabled' not in command_result.stdout"
-  when: plugins.registry
+  when: microk8s_plugins.registry
 
 - name: Disable registry
   become: yes
   command: "microk8s.disable registry:size={{ registry_size }}"
   register: command_result
   changed_when: "'Addon registry is already disabled' not in command_result.stdout"
-  when: not plugins.registry
+  when: not microk8s_plugins.registry
 
 - name: Disable snap autoupdate
   blockinfile:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -74,47 +74,21 @@
   register: command_result
   changed_when: "'0 added, 0 removed' not in command_result.stdout"
 
-- name: Enable rbac
+- name: Enable {{ item.key }}
   become: yes
-  command: "microk8s.enable rbac"
+  loop: "{{ plugins | dict2items | item.key != 'registry'}}"
+  command: "microk8s.enable {{ item.key }}"
   register: command_result
-  changed_when: "'Addon rbac is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_rbac_enable
+  changed_when: "'Addon {{ item.key }} is already enabled' not in command_result.stdout"
+  when: item.value
 
-- name: Disable rbac
+- name: Disable {{ item.key }}
   become: yes
-  command: "microk8s.disable rbac"
+  loop: "{{ plugins | dict2items | item.value != 'registry'}}"
+  command: "microk8s.disable {{ item.key }}"
   register: command_result
-  changed_when: "'Addon rbac is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_rbac_enable
-
-- name: Enable dns
-  become: yes
-  command: "microk8s.enable dns"
-  register: command_result
-  changed_when: "'Addon dns is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_dns_enable
-
-- name: Disable dns
-  become: yes
-  command: "microk8s.disable dns"
-  register: command_result
-  changed_when: "'Addon dns is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_dns_enable
-
-- name: Enable storage
-  become: yes
-  command: "microk8s.enable storage"
-  register: command_result
-  changed_when: "'Addon storage is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_storage_enable
-
-- name: Disable storage
-  become: yes
-  command: "microk8s.disable storage"
-  register: command_result
-  changed_when: "'Addon storage is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_storage_enable
+  changed_when: "'Addon {{ item.key }} is already disabled' not in command_result.stdout"
+  when: not item.value
 
 - name: Enable registry
   become: yes
@@ -129,132 +103,6 @@
   register: command_result
   changed_when: "'Addon registry is already disabled' not in command_result.stdout"
   when: not microk8s_plugin_registry_enable
-
-- name: Enable metrics-server
-  become: yes
-  command: "microk8s.enable metrics-server"
-  register: command_result
-  changed_when: "'Addon metrics-server is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_metricsserver_enable
-
-- name: Disable metrics-server
-  become: yes
-  command: "microk8s.disable metrics-server"
-  register: command_result
-  changed_when: "'Addon metrics-server is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_metricsserver_enable
-
-- name: Enable helm3
-  become: yes
-  command: "microk8s.enable helm3"
-  register: command_result
-  changed_when: "'Addon helm3 is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_helm3_enable
-
-- name: Disable helm3
-  become: yes
-  command: "microk8s.disable helm3"
-  register: command_result
-  changed_when: "'Addon helm3 is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_helm3_enable
-
-- name: Enable ingress
-  become: yes
-  command: "microk8s.enable ingress"
-  register: command_result
-  changed_when: "'Addon ingress is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_ingress_enable
-
-- name: Disable ingress
-  become: yes
-  command: "microk8s.disable ingress"
-  register: command_result
-  changed_when: "'Addon ingress is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_ingress_enable
-
-- name: Enable dashboard
-  become: yes
-  command: "microk8s.enable dashboard"
-  register: command_result
-  changed_when: "'Addon dashboard is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_dashboard_enable
-
-- name: Disable dashboard
-  become: yes
-  command: "microk8s.disable dashboard"
-  register: command_result
-  changed_when: "'Addon dashboard is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_dashboard_enable
-
-- name: Enable fluentd
-  become: yes
-  command: "microk8s.enable fluentd"
-  register: command_result
-  changed_when: "'Addon fluentd is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_fluentd_enable
-
-- name: Disable fluentd
-  become: yes
-  command: "microk8s.disable fluentd"
-  register: command_result
-  changed_when: "'Addon fluentd is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_fluentd_enable
-
-- name: Enable prometheus
-  become: yes
-  command: "microk8s.enable prometheus"
-  register: command_result
-  changed_when: "'Addon prometheus is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_prometheus_enable
-
-- name: Disable prometheus
-  become: yes
-  command: "microk8s.disable prometheus"
-  register: command_result
-  changed_when: "'Addon prometheus is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_prometheus_enable
-
-- name: Enable metallb
-  become: yes
-  command: "microk8s.enable metallb"
-  register: command_result
-  changed_when: "'Addon metallb is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_metallb_enable
-
-- name: Disable metallb
-  become: yes
-  command: "microk8s.disable metallb"
-  register: command_result
-  changed_when: "'Addon metallb is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_metallb_enable
-
-- name: Enable host access
-  become: yes
-  command: "microk8s.enable host-access"
-  register: command_result
-  changed_when: "'Addon host-access is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_host_access_enable
-
-- name: Disable host access
-  become: yes
-  command: "microk8s.disable host-access"
-  register: command_result
-  changed_when: "'Addon host-access is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_host_access_enable
-
-- name: Enable traefik
-  become: yes
-  command: "microk8s.enable traefik"
-  register: command_result
-  changed_when: "'Addon traefik is already enabled' not in command_result.stdout"
-  when: microk8s_plugin_traefik_enable
-
-- name: Disable traefik
-  become: yes
-  command: "microk8s.disable traefik"
-  register: command_result
-  changed_when: "'Addon traefik is already disabled' not in command_result.stdout"
-  when: not microk8s_plugin_traefik_enable
 
 - name: Disable snap autoupdate
   blockinfile:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
   command: "snap alias microk8s.helm3 helm"
   changed_when: false
   register: aliashelmout
-  when: plugins.helm
+  when: plugins.helm3
 
 - name: Create custom certificates
   become: yes


### PR DESCRIPTION
Allows for any present and future plugins to be installed, while keeping the same defaults.
I understand this might not be backportable. This can move to a major version update or alternatively I can backport the previously existing vars if preferred.
One caveat is once the `microk8s_plugins` default is overrriden, all plugins to be included must be explicit in the var. Ansible can merge the var over the defaults instead by setting the [DEFAULT_HASH_BEHAVIOUR](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-hash-behaviour) setting to `merge`