### PR TITLE
Fix plugins variable reference

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
   command: "snap alias microk8s.helm3 helm"
   changed_when: false
   register: aliashelmout
-  when: plugins.helm3
+  when: microk8s_plugins.helm3
 
 - name: Create custom certificates
   become: yes


### PR DESCRIPTION
The line references an invalid variable, which fails on execution. Fixing the variable to be "microk8s_plugins" instead of just "plugins"