### PR TITLE
Run HA operations with sudo

### DIFF
--- a/tasks/configure-HA.yml
+++ b/tasks/configure-HA.yml
@@ -42,5 +42,5 @@
   - name: Set the microk8s join command on the microk8s node
     command: "{{ microk8s_join_command.stdout }}"
     when: microk8s_cluster_node.stdout.find(inventory_hostname) == -1
-
+  become: yes
   when: inventory_hostname != designated_host


### PR DESCRIPTION
Since the role performs all the snap operations with sudo instead of allowing the ansible_ssh_user to perform them, the HA ops also need sudo, otherwise they fail. 