### PR TITLE
Make it possible to join nodes via non-default interace

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,5 +48,8 @@ microk8s_enable_HA: false
 # hostgroup whose members will form high-availability cluster
 microk8s_group_HA: "microk8s_HA"
 
+# regex to select IP address for joining nodes in HA setup
+microk8s_ip_regex_HA: "([0-9]{1,3}[\\.]){3}[0-9]{1,3}"
+
 # for setting up custom certificate request.  Set to template name to enable
 #microk8s_csr_template: null

--- a/tasks/configure-HA.yml
+++ b/tasks/configure-HA.yml
@@ -22,7 +22,7 @@
     changed_when: false
 
   - name: Get the microk8s join command from the microk8s master
-    shell: "microk8s add-node | head -n 2 | tail -n 1"
+    shell: "microk8s add-node | grep -E -m1 'microk8s join {{ microk8s_ip_regex_HA }}'"
     delegate_to: "{{ designated_host }}"
     delegate_facts: true
     changed_when: false


### PR DESCRIPTION
I have a need to join nodes on internal network `10.0.0.0/16`. This PR adds regex to filter `microk8s add-node` output to select to which interface to join nodes.