### PR TITLE
move addons to separate file for better HA support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ microk8s_plugins:
   prometheus: false    # Prometheus operator for monitoring and logging
   traefik: false
 
+microk8s_dns_resolvers: 8.8.8.8,8.8.4.4
 
 registry_size: 20Gi
 helm3_repositories:

--- a/tasks/addons.yml
+++ b/tasks/addons.yml
@@ -1,0 +1,40 @@
+- name: Enable plugins
+  become: yes
+  loop: "{{ microk8s_plugins | dict2items }}"
+  command: "microk8s.enable {{ item.key }}"
+  loop_control:
+    label: "{{ item.key }}"
+  register: command_result
+  changed_when: "'Addon ' + item.key + ' is already enabled' not in command_result.stdout"
+  when:
+    - item.value
+    - item.key != "dns"
+    - item.key != "registry"
+
+- name: Disable plugins
+  become: yes
+  loop: "{{ microk8s_plugins | dict2items }}"
+  command: "microk8s.disable {{ item.key }}"
+  loop_control:
+    label: "{{ item.key }}"
+  register: command_result
+  changed_when: "'Addon ' + item.key + ' is already disabled' not in command_result.stdout"
+  when: not item.value
+
+- name: Enable dns
+  become: yes
+  command: "microk8s.enable dns:{{ microk8s_dns_resolvers }}"
+  register: command_result
+  changed_when: "'Addon dns is already enabled' not in command_result.stdout"
+  when:
+    - "'dns' in microk8s_plugins"
+    - microk8s_plugins.dns
+
+- name: Enable registry
+  become: yes
+  command: "microk8s.enable registry:size={{ registry_size }}"
+  register: command_result
+  changed_when: "'Addon registry is already enabled' not in command_result.stdout"
+  when:
+    - "'registry' in microk8s_plugins"
+    - microk8s_plugins.registry

--- a/tasks/configure-HA.yml
+++ b/tasks/configure-HA.yml
@@ -44,3 +44,7 @@
     when: microk8s_cluster_node.stdout.find(inventory_hostname) == -1
   become: yes
   when: inventory_hostname != designated_host
+
+- name: configure cluster addons
+  include_tasks: addons.yml
+  when: inventory_hostname == designated_host

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -74,40 +74,6 @@
   register: command_result
   changed_when: "'0 added, 0 removed' not in command_result.stdout"
 
-- name: Enable plugins
-  become: yes
-  loop: "{{ microk8s_plugins | dict2items }}"
-  command: "microk8s.enable {{ item.key }}"
-  loop_control: 
-    label: "{{ item.key }}"
-  register: command_result
-  changed_when: "'Addon {{ item.key }} is already enabled' not in command_result.stdout"
-  when: item.value and item.key != "registry"
-
-- name: Disable plugins
-  become: yes
-  loop: "{{ microk8s_plugins | dict2items }}"
-  command: "microk8s.disable {{ item.key }}"
-  loop_control: 
-    label: "{{ item.key }}"
-  register: command_result
-  changed_when: "'Addon {{ item.key }} is already disabled' not in command_result.stdout"
-  when: not item.value and item.key != "registry"
-
-- name: Enable registry
-  become: yes
-  command: "microk8s.enable registry:size={{ registry_size }}"
-  register: command_result
-  changed_when: "'Addon registry is already enabled' not in command_result.stdout"
-  when: microk8s_plugins.registry
-
-- name: Disable registry
-  become: yes
-  command: "microk8s.disable registry:size={{ registry_size }}"
-  register: command_result
-  changed_when: "'Addon registry is already disabled' not in command_result.stdout"
-  when: not microk8s_plugins.registry
-
 - name: Disable snap autoupdate
   blockinfile:
     dest: /etc/hosts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,10 @@
   include_tasks: configure-groups.yml
   when: "users is defined and users not in ([], None, '', omit)"
 
+- name: configure single node addons
+  include_tasks: addons.yml
+  when: not microk8s_enable_HA
+
 - name: configure High Availability
   include_tasks: configure-HA.yml
   when: "microk8s_enable_HA"


### PR DESCRIPTION
Addons are only configured on a single node in an HA environment and installing them on all nodes causes errors.

Also:
- Reformatted `changed_when` for addons to eliminate warning `[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: 'Addon {{ item.key }} is already disabled' not in command_result.stdout`
- Adds `microk8s_dns_resolvers` for customizing DNS addon upstream resolvers. Chose [documented](https://microk8s.io/docs/addon-dns) default as default
- Remove disable registry task since it doesn't need the argument to be disabled.
