### PR TITLE
Add become:true for disable snap autoupdate

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -77,6 +77,7 @@
   changed_when: "'0 added, 0 removed' not in command_result.stdout"
 
 - name: Disable snap autoupdate
+  become: true
   blockinfile:
     dest: /etc/hosts
     marker: "# {mark} ANSIBLE MANAGED: microk8s Disable snap autoupdate"


### PR DESCRIPTION
closes: #23

Simple fix so that `become` is used to ensure snapd doesn't just randomly update the cluster