### PR TITLE
Make it possible to configure worker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ defined in `[defaults/main.yml](defaults/main.yml)`.
 * `microk8s_plugins`: Enable/disable various plugins. A string will be passed as `arg` when enabling addon using `name:arg`
 * `microk8s_enable_HA`: Enable/disable high-availability.
 * `microk8s_group_HA`: Hostgroup whose members will form HA cluster.
+* `microk8s_group_WORKERS`: Hostgroup whose members will act as worker nodes only (no control-plane components run here)
 * `microk8s_csr_template`: If defined, will cause a custom CSR to be used in
   generating certificates.
 
@@ -55,6 +56,10 @@ a template, and then copy the CSR in
 `/var/snap/microk8s/current/certs/csr.conf.template` to your playbook's
 templates directory, make the edits and set the `microk8s_csr_template`
 variable accordingly, and re-run the playbook.
+
+### Adding worker only nodes (1.23+ only)
+
+It is possible to configure additional nodes to act as workers only within your microk8s cluster. This is possible by configuring the ansible hostgroup `microk8s_WORKERS` (name of the group is configurable via `microk8s_group_WORKERS`). Every host listed within the hostgroup will essentially run `microk8s join .... --worker`, more info on this can be found here: [microk8s-clustering](https://microk8s.io/docs/clustering).
 
 ## Testing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,5 +56,8 @@ microk8s_group_HA: "microk8s_HA"
 # regex to select IP address for joining nodes in HA setup
 microk8s_ip_regex_HA: "([0-9]{1,3}[\\.]){3}[0-9]{1,3}"
 
+# hostgroup whose members will act as worker nodes only (no control-plane components run here)
+microk8s_group_WORKERS: "microk8s_WORKERS"
+
 # for setting up custom certificate request.  Set to template name to enable
 #microk8s_csr_template: null

--- a/tasks/configure-WORKERS.yml
+++ b/tasks/configure-WORKERS.yml
@@ -1,15 +1,5 @@
 ---
 
-- name: Enumerate all cluster hosts within the hosts file
-  become: yes
-  blockinfile:
-    dest: /etc/hosts
-    marker: "# {mark} ANSIBLE MANAGED: microk8s HA Cluster Hosts"
-    content: |
-      {% for host in groups[microk8s_group_HA] %}
-      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_hostname }}
-      {% endfor %}
-
 - name: Find the designated host
   set_fact:
     designated_host: '{{ (groups[microk8s_group_HA]|sort)[0] }}'
@@ -40,7 +30,7 @@
     changed_when: false
 
   - name: Set the microk8s join command on the microk8s node
-    command: "{{ microk8s_join_command.stdout }}"
+    command: "{{ microk8s_join_command.stdout }} --worker"
     when: microk8s_cluster_node.stdout.find(inventory_hostname) == -1
     register: join_command_output
     failed_when:
@@ -50,8 +40,4 @@
   become: yes
   when:
     - inventory_hostname != designated_host
-    - inventory_hostname in groups[microk8s_group_HA]
-
-- name: configure cluster addons
-  include_tasks: addons.yml
-  when: inventory_hostname == designated_host
+    - inventory_hostname in groups[microk8s_group_WORKER]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,7 @@
 - name: configure High Availability
   include_tasks: configure-HA.yml
   when: "microk8s_enable_HA"
+
+- name: configure workers
+  include_tasks: configure-WORKERS.yml
+  when: "groups[microk8s_group_WORKERS]|length>0"


### PR DESCRIPTION
closes: #27 

Using the default hostgroup name of microk8s_WORKERS it is now possible to create worker-only nodes in 1.23+ of microk8s.

This is pretty much a copy/paste of the `configure-HA` but with the addition of two key pieces:

- `--worker` on the join command
- A check to see if the `host` currently being configured belongs to HA or WORKER