### PR TITLE
Fix re-runs of role with workers

### DIFF
--- a/tasks/configure-WORKERS.yml
+++ b/tasks/configure-WORKERS.yml
@@ -25,9 +25,13 @@
     changed_when: false
     register: microk8s_cluster_node
 
-  - name: Waiting for microk8s to be ready on microk8s host node
+  - name: Waiting for microk8s to be ready on microk8s worker node
     command: "microk8s status --wait-ready"
     changed_when: false
+    register: status_command_output
+    failed_when:
+      - "'This MicroK8s deployment is acting as a node in a cluster.' not in status_command_output.stdout_lines"
+      - status_command_output.rc > 0
 
   - name: Set the microk8s join command on the microk8s node
     command: "{{ microk8s_join_command.stdout }} --worker"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -26,6 +26,10 @@
   command: microk8s.status --wait-ready
   changed_when: false
   register: mk8sstatusout
+  failed_when:
+      - "'This MicroK8s deployment is acting as a node in a cluster.' not in mk8sstatusout.stdout_lines"
+      - mk8sstatusout.rc > 0
+
 
 - name: Create kubectl alias
   become: yes


### PR DESCRIPTION
Re-running this role fails for `workers` since `--wait-ready` throws an error. Adding in these snippets to handle that