### PR TITLE
Adding optional value for worker hostname discovery

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,5 +59,8 @@ microk8s_ip_regex_HA: "([0-9]{1,3}[\\.]){3}[0-9]{1,3}"
 # hostgroup whose members will act as worker nodes only (no control-plane components run here)
 microk8s_group_WORKERS: "microk8s_WORKERS"
 
+# option to add workers hostgroup memembers to hostfile
+add_workers_to_hostfile: false
+
 # for setting up custom certificate request.  Set to template name to enable
 #microk8s_csr_template: null

--- a/tasks/configure-HA.yml
+++ b/tasks/configure-HA.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Enumerate all cluster hosts within the hosts file
+- name: Enumerate all cluster HA hosts within the hosts file
   become: yes
   blockinfile:
     dest: /etc/hosts
@@ -9,6 +9,17 @@
       {% for host in groups[microk8s_group_HA] %}
       {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_hostname }}
       {% endfor %}
+
+- name: Enumerate all cluster worker hosts within the hosts file
+  become: yes
+  blockinfile:
+    dest: /etc/hosts
+    marker: "# {mark} ANSIBLE MANAGED: microk8s WORKER Cluster Hosts"
+    content: |
+      {% for host in groups[microk8s_group_WORKERS] %}
+      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_hostname }}
+      {% endfor %}
+  when: add_workers_to_hostfile
 
 - name: Find the designated host
   set_fact:


### PR DESCRIPTION
This change helps mitigate microk8s issue https://github.com/canonical/microk8s/issues/1566.
Essentially any pod not running on an api server node will not have DNS/hostname discovery. Commands like "kubectl logs <pod>" will fail due to the api servers not being able to resolve the hostname of the workers in a cluster not attached to a network with a DNS/L3 resolver.