### PR TITLE
Bugfix

### DIFF
--- a/tasks/addons.yml
+++ b/tasks/addons.yml
@@ -4,6 +4,7 @@
     cmd: microk8s.status --format yaml
   changed_when: no
   register: microk8s_status
+  check_mode: no
 
 - name: set current state fact
   set_fact:


### PR DESCRIPTION
Role cannot be run in --check mode, this fixes it.

I added `check_mode: no` to a step in addons.yml, which allows a specific information gathering step to run, which is needed when checking what would be changed if the playbook were to be run without --check mode specified.  