### PR TITLE
Raspberry Dependencies + Minor Install Adjustment

### DIFF
--- a/tasks/configure-WORKERS.yml
+++ b/tasks/configure-WORKERS.yml
@@ -34,7 +34,7 @@
       - status_command_output.rc > 0
 
   - name: Set the microk8s join command on the microk8s node
-    command: "{{ microk8s_join_command.stdout }}"
+    command: "{{ microk8s_join_command.stdout }} --worker"
     when: microk8s_cluster_node.stdout.find(inventory_hostname) == -1
     register: join_command_output
     failed_when:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,10 @@
 - name: Make sure snapd is installed
-  apt:
+  package:
     name:
       - snapd
-    update_cache: yes
-    state: present
+    state: latest
   become: yes
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution != 'Archlinux'
 
 - name: Make sure snapd is installed
   pacman:
@@ -14,6 +13,17 @@
     state: present
   become: yes
   when: ansible_distribution == 'Archlinux'
+
+- name: Check if is raspberry
+  shell: "uname -r"
+  register: uname
+
+- name: Install raspberry specific packages
+  package:
+    name:
+      - linux-modules-extra-raspi
+    state: latest
+  when: uname.stdout | regex_search('raspi')
 
 - name: Install microk8s
   become: yes


### PR DESCRIPTION
This PR will install the dependencies for Raspberry Pi to run smoothly. 

Also, I changed the Ansible `apt` by `package` to allow other package managers like `yum` and `dns`. I am uncertain if `package` can install `pacman` on Arch Linux, so I kept it because I can't test it. 

One final change is the Worker join. It was missing the flag `--worker`

It is tested on my local.