### PR TITLE
fix wrong user home dir for .kube directory 

### DIFF
--- a/tasks/configure-groups.yml
+++ b/tasks/configure-groups.yml
@@ -1,5 +1,21 @@
 # add user specific settings
 ---
+
+# Fetch home directories of users https://stackoverflow.com/a/48892377
+- user:
+    name: '{{ user }}'
+    state: present
+  register: user_info
+  with_items: '{{ users }}'
+  loop_control:
+    loop_var: user
+    label: '{{ user }}'
+
+- name: Transform user_homes into a dictionary
+  set_fact:
+    user_info_dict: "{{ user_info_dict | default({}) | combine({item['user']: item}) }}"
+  with_items: "{{ user_info.results }}"
+
 - name: add user to group
   become: yes
   command: "usermod -a -G microk8s {{ user }}"
@@ -13,7 +29,7 @@
   become: yes
   become_user: '{{ user }}'
   file:
-    path: ~/.kube
+    path: "{{ user_info_dict[user]['home'] }}/.kube"
     state: directory
     owner: '{{ user }}'
     group: '{{ user }}'
@@ -26,7 +42,7 @@
 - name: create kubectl config
   become: yes
   changed_when: true
-  shell: microk8s config > /home/{{ user }}/.kube/config
+  shell: microk8s config > {{ user_info_dict[user]['home'] }}/.kube/config
   args:
     executable: /bin/bash
   with_items: '{{ users }}'
@@ -37,7 +53,7 @@
 - name: reaffirm permission on files
   become: yes
   file:
-    path: ~/.kube
+    path: "{{ user_info_dict[user]['home'] }}/.kube"
     state: directory
     owner: '{{ user }}'
     group: '{{ user }}'


### PR DESCRIPTION
Existing implementation resolves `~` placeholder to root user dir (probably because of `become: yes`). That breaks an intended logic, because the `.kube` directory is created inside the root user home, and then assigned `user` ownership. 

```
    "ansible_loop_var": "user",
    "changed": false,
    "diff": {
        "after": {
            "path": "/root/.kube"
        },
        "before": {
            "path": "/root/.kube"
        }
    },
    "gid": 1000,
```
As a result, the `Create .kube folder for the user` task fails with `cannot access '/home/userx/.kube/config': No such file or directory`

There is yet another related issue https://github.com/istvano/ansible_role_microk8s/issues/41 with the exact cause.

Proposed changes resolve the correct user home directory, and substitute it instead of `~` , so now the logic works as intended
```
    "ansible_loop_var": "user",
    "changed": true,
    "diff": {
        "after": {
            "group": 1000,
            "mode": "0750",
            "owner": 1000,
            "path": "/home/userx/.kube",
            "state": "directory"
        },
        "before": {
            "group": 0,
            "mode": "0755",
            "owner": 0,
            "path": "/home/userx/.kube",
            "state": "absent"
        }

```

