### PR TITLE
fix: fix typo in `determine_versions`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ microk8s_ip_regex_HA: "([0-9]{1,3}[\\.]){3}[0-9]{1,3}"
 # hostgroup whose members will act as worker nodes only (no control-plane components run here)
 microk8s_group_WORKERS: "microk8s_WORKERS"
 
-# option to add workers hostgroup memembers to hostfile
+# option to add workers hostgroup members to hostfile
 add_workers_to_hostfile: false
 
 # for setting up custom certificate request.  Set to template name to enable

--- a/moleculew
+++ b/moleculew
@@ -331,14 +331,14 @@ print_versions() {
 }
 
 wrapper_versions() {
-    detemine_versions
+    determine_versions
 
     print_versions
     exit
 }
 
 wrapper_freeze() {
-    detemine_versions
+    determine_versions
 
     banner 'Freezing versions'
 
@@ -386,7 +386,7 @@ wrapper_unfreeze() {
 }
 
 wrapper_upgrade_versions() {
-    detemine_versions
+    determine_versions
 
     banner 'Upgrading versions'
 
@@ -691,7 +691,7 @@ parse_args() {
     set -e
 }
 
-detemine_versions() {
+determine_versions() {
     if [[ $USE_SYSTEM_DEPENDENCIES == false ]]; then
         USE_SYSTEM_DEPENDENCIES="$MOLECULEW_USE_SYSTEM"
     fi
@@ -802,7 +802,7 @@ detemine_versions() {
 }
 
 activate_virtualenv() {
-    detemine_versions
+    determine_versions
 
     MOLECULE_WRAPPER_ENV="$HOME/.moleculew/ml-${MOLECULE_VERSION}_an-${ANSIBLE_VERSION}_py-${PYTHON_VERSION}_yl-${YAMLLINT_VERSION}_al-${ANSIBLE_LINT_VERSION}_f8-${FLAKE8_VERSION}_ti-${TESTINFRA_VERSION}"
 


### PR DESCRIPTION
Fixed a typo in `determine_versions` func.